### PR TITLE
Compile the shared library with cgo code added to the sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,14 @@
 .pub/
 
 build/
+
+android/.classpath
+android/.cxx/
+android/.project
+android/.settings/
+android/gobin/
+example/android/.project
+example/android/.settings/
+linux/Debug/
+linux/compile_commands.json
+linux/flutter/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,21 @@
 set(WORMHOLE_WILLIAM_LIB
     ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libwormhole_william.so)
 
+if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
+  set(EXPORT set)
+else()
+  set(EXPORT export)
+endif()
+
 add_custom_target(
   BUILD_GO_LIBRARY ALL
-  COMMENT Building
-  go static library
-  # TODO I couldn't find a better way to pass the environment variables, but I
-  # believe there should be
-  COMMAND
-    CGO_ENABLED=1 GOARCH=${GOARCH} GOOS=${GOOS} CC_FOR_TARGET=${CC_FOR_TARGET}
-    CC=${CC_FOR_TARGET} go build -buildmode=c-shared -o ${WORMHOLE_WILLIAM_LIB}
-    ./c/client.c.go
+  COMMENT Building go static library
+  COMMAND ${EXPORT} CGO_ENABLED=1&&
+  	  ${EXPORT} GOARCH=${GOARCH}&&
+	  ${EXPORT} GOOS=${GOOS}&&
+	  ${EXPORT} CC_FOR_TARGET=${CC_FOR_TARGET}&&
+	  ${EXPORT} CC=${CC_FOR_TARGET}&&
+	  go build -buildmode=c-shared -o ${WORMHOLE_WILLIAM_LIB} ./c/client.c.go
   USES_TERMINAL
   BYPRODUCTS ${WORMHOLE_WILLIAM_LIB}
   WORKING_DIRECTORY ${WORMHOLE_WILLIAM_GO_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+set(WORMHOLE_WILLIAM_LIB
+    ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/libwormhole_william.so)
+
+add_custom_target(
+  BUILD_GO_LIBRARY ALL
+  COMMENT Building
+  go static library
+  # TODO I couldn't find a better way to pass the environment variables, but I
+  # believe there should be
+  COMMAND
+    CGO_ENABLED=1 GOARCH=${GOARCH} GOOS=${GOOS} CC_FOR_TARGET=${CC_FOR_TARGET}
+    CC=${CC_FOR_TARGET} go build -buildmode=c-shared -o ${WORMHOLE_WILLIAM_LIB}
+    ./c/client.c.go
+  USES_TERMINAL
+  BYPRODUCTS ${WORMHOLE_WILLIAM_LIB}
+  WORKING_DIRECTORY ${WORMHOLE_WILLIAM_GO_DIR})
+
+add_library(
+  WORMHOLE_GO
+  SHARED
+  IMPORTED
+  DEPENDS ${WORMHOLE_WILLIAM_LIB}
+  IMPORTED_LOCATION ${WORMHOLE_WILLIAM_LIB}
+  GLOBAL)
+
+target_link_libraries(${PLUGIN_NAME} PUBLIC ${WORMHOLE_WILLIAM_LIB})

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -6,12 +6,35 @@ project(${PROJECT_NAME} LANGUAGES CXX C)
 # changed
 set(PLUGIN_NAME "dart_wormhole_william_plugin")
 
-execute_process(
-  COMMAND go tool cgo c/client.c.go COMMAND_ERROR_IS_FATAL LAST
-  WORKING_DIRECTORY
-    ${CMAKE_SOURCE_DIR}/../dart_wormhole_william/wormhole-william)
+# The golden GOOS
+set(GOOS android)
 
-set(WORMHOLE_C_WRAPPER_BASE "${CMAKE_SOURCE_DIR}/../wormhole-william/_obj")
-file(GLOB_RECURSE WORMHOLE_C_WRAPPER_SRC ${WORMHOLE_C_WRAPPER_BASE}/*.c
-     ${WORMHOLE_C_WRAPPER_BASE}/*.h)
-add_library(${PLUGIN_NAME} SHARED "src/main/c/test.c;${WORMHOLE_C_WRAPPER_SRC}")
+set(CC_FOR_TARGET ${CMAKE_C_COMPILER})
+
+if(ANDROID_ABI STREQUAL "x86_64")
+  set(GOARCH "amd64")
+elseif(ANDROID_ABI STREQUAL "arm64-v8a")
+  set(GOARCH "arm64")
+elseif(ANDROID_ABI STREQUAL "armeabi-v7a")
+  set(GOARCH "arm")
+elseif(ANDROID_ABI STREQUAL "x86")
+  set(GOARCH "386")
+else()
+  set(GOARCH "please-fail :/")
+endif()
+
+set(WORMHOLE_WILLIAM_GO_DIR ${CMAKE_SOURCE_DIR}/../wormhole-william)
+
+set(CC_FOR_TARGET ${ANDROID_TOOLCHAIN_ROOT}/bin/${CMAKE_C_COMPILER_TARGET}-clang)
+
+# Fix the clang triplet used as parameter for -target flag. compiler with -none-
+# are not in the ndk
+string(REPLACE "-none" "" CC_FOR_TARGET ${CC_FOR_TARGET})
+
+# For some reason CMAKE_C_COMPILER_TARGET is named differently for this
+# architecture than the one that comes with the ndk armv7 vs armv7a
+string(REPLACE "armv7-" "armv7a-" CC_FOR_TARGET ${CC_FOR_TARGET})
+
+add_library(${PLUGIN_NAME} SHARED "src/main/c/dummy.c")
+
+include(../CMakeLists.txt)

--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.10)
+set(PROJECT_NAME "dart_wormhole_william")
+project(${PROJECT_NAME} LANGUAGES CXX C)
+
+# This value is used when generating builds using this plugin, so it must not be
+# changed
+set(PLUGIN_NAME "dart_wormhole_william_plugin")
+
+execute_process(
+  COMMAND go tool cgo c/client.c.go COMMAND_ERROR_IS_FATAL LAST
+  WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}/../dart_wormhole_william/wormhole-william)
+
+set(WORMHOLE_C_WRAPPER_BASE "${CMAKE_SOURCE_DIR}/../wormhole-william/_obj")
+file(GLOB_RECURSE WORMHOLE_C_WRAPPER_SRC ${WORMHOLE_C_WRAPPER_BASE}/*.c
+     ${WORMHOLE_C_WRAPPER_BASE}/*.h)
+add_library(${PLUGIN_NAME} SHARED "src/main/c/test.c;${WORMHOLE_C_WRAPPER_SRC}")

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,16 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
+    defaultConfig {
+        ndk {
+            abiFilters "x86_64", "arm64-v8a"
+        }
+    }
+    externalNativeBuild {
+        cmake {
+            path "CMakeLists.txt"
+        }
+    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,11 +33,6 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
-    defaultConfig {
-        ndk {
-            abiFilters "x86_64", "arm64-v8a"
-        }
-    }
     externalNativeBuild {
         cmake {
             path "CMakeLists.txt"

--- a/android/src/main/c/dummy.c
+++ b/android/src/main/c/dummy.c
@@ -1,0 +1,1 @@
+// Dummy file for gradle to work

--- a/android/src/main/c/test.c
+++ b/android/src/main/c/test.c
@@ -1,0 +1,5 @@
+int test() {
+  // TODO just for testing loading and that the shared library has teh correct symbols
+  // Add code that uses the client
+  return 0;
+}

--- a/android/src/main/c/test.c
+++ b/android/src/main/c/test.c
@@ -1,5 +1,0 @@
-int test() {
-  // TODO just for testing loading and that the shared library has teh correct symbols
-  // Add code that uses the client
-  return 0;
-}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -64,6 +64,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -33,12 +33,12 @@ class ClientNative {
   late final ClientRecvText clientRecvText;
 
   String get dylibPath {
-    String libraryPath = path.join(dylibDir, 'wormhole.so');
+    String libraryPath = path.join("libdart_wormhole_william_plugin.so");
     if (Platform.isMacOS) {
-      libraryPath = path.join(dylibDir, 'wormhole.dylib');
+      libraryPath = path.join('libdart_wormhole_william_plugin.dylib');
     }
     if (Platform.isWindows) {
-      libraryPath = path.join(dylibDir, 'wormhole.dll');
+      libraryPath = path.join('libdart_wormhole_william_plugin.dll');
     }
     return libraryPath;
   }
@@ -71,7 +71,8 @@ class Client {
 //    String _dylibDir = path.join(
 //        path.dirname(Frame.caller(1).uri.path), '..', 'wormhole-william', 'build');
     // TODO: figure this out!
-    String _dylibDir = '/home/bwhite/Projects/flutter_wormhole_gui/dart_wormhole_william/wormhole-william/build';
+    // String _dylibDir = '/home/bwhite/Projects/flutter_wormhole_gui/dart_wormhole_william/wormhole-william/build';
+    String _dylibDir = 'lib';
 
     _native = ClientNative(dylibDir: _dylibDir);
     this.goClient = _native.newClient();

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -22,8 +22,6 @@ typedef ClientRecvText = int Function(
     int, Pointer<Utf8> goClientIndex, Pointer<Pointer<Utf8>> msg);
 
 class ClientNative {
-  final String dylibDir;
-
   late final DynamicLibrary? _dylib;
 
   late final NewClient newClient;
@@ -43,7 +41,7 @@ class ClientNative {
     return libraryPath;
   }
 
-  ClientNative({required String this.dylibDir}) {
+  ClientNative() {
     _dylib = DynamicLibrary.open(dylibPath);
 
     newClient =
@@ -65,24 +63,20 @@ class Client {
 
   late ClientNative _native;
 
-  // TODO: config
   Client() {
-    // TODO: something better?
-//    String _dylibDir = path.join(
-//        path.dirname(Frame.caller(1).uri.path), '..', 'wormhole-william', 'build');
-    // TODO: figure this out!
-    // String _dylibDir = '/home/bwhite/Projects/flutter_wormhole_gui/dart_wormhole_william/wormhole-william/build';
-    String _dylibDir = 'lib';
-
-    _native = ClientNative(dylibDir: _dylibDir);
-    this.goClient = _native.newClient();
+    _native = ClientNative();
+    this.goClient = _native.newClient.call();
   }
 
   String sendText(String msg) {
     Pointer<Pointer<Utf8>> _codeOut = calloc();
     final int statusCode =
         _native.clientSendText(goClient, msg.toNativeUtf8(), _codeOut);
+
     // TODO: error handling (statusCode != 0)
+    if (statusCode != 0) {
+      throw "Failed to send text. Error code: $statusCode";
+    }
 
     final Pointer<Utf8> _code = _codeOut.value;
     calloc.free(_codeOut);

--- a/lib/client.dart
+++ b/lib/client.dart
@@ -31,7 +31,7 @@ class ClientNative {
   late final ClientRecvText clientRecvText;
 
   String get dylibPath {
-    String libraryPath = path.join("libdart_wormhole_william_plugin.so");
+    String libraryPath = path.join('libdart_wormhole_william_plugin.so');
     if (Platform.isMacOS) {
       libraryPath = path.join('libdart_wormhole_william_plugin.dylib');
     }
@@ -73,7 +73,6 @@ class Client {
     final int statusCode =
         _native.clientSendText(goClient, msg.toNativeUtf8(), _codeOut);
 
-    // TODO: error handling (statusCode != 0)
     if (statusCode != 0) {
       throw "Failed to send text. Error code: $statusCode";
     }

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -2,31 +2,31 @@ cmake_minimum_required(VERSION 3.10)
 set(PROJECT_NAME "dart_wormhole_william")
 project(${PROJECT_NAME} LANGUAGES CXX C)
 
+set(WORMHOLE_WILLIAM_GO_DIR
+    ${CMAKE_SOURCE_DIR}/../dart_wormhole_william/wormhole-william)
+
 # This value is used when generating builds using this plugin, so it must not be
 # changed
 set(PLUGIN_NAME "dart_wormhole_william_plugin")
 
-execute_process(
-  COMMAND go tool cgo c/client.c.go
-  COMMAND_ERROR_IS_FATAL LAST
-  WORKING_DIRECTORY
-    ${CMAKE_SOURCE_DIR}/../dart_wormhole_william/wormhole-william)
-
-set(WORMHOLE_C_WRAPPER_BASE
-    "${CMAKE_SOURCE_DIR}/../dart_wormhole_william/wormhole-william/_obj")
-file(GLOB_RECURSE WORMHOLE_C_WRAPPER_SRC ${WORMHOLE_C_WRAPPER_BASE}/*.c
-     ${WORMHOLE_C_WRAPPER_BASE}/*.h)
-add_library(${PLUGIN_NAME} SHARED
-            "dart_wormhole_william_plugin.cc;${WORMHOLE_C_WRAPPER_SRC}")
+add_library(${PLUGIN_NAME} SHARED "dart_wormhole_william_plugin.cc")
 
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
-target_include_directories(
-  ${PLUGIN_NAME}
-  INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include;${WORMHOLE_C_WRAPPER_BASE}")
+target_include_directories(${PLUGIN_NAME}
+                           INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+target_link_libraries(${PLUGIN_NAME} PUBLIC ${WORMHOLE_WILLIAM_LIB})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 # List of absolute paths to libraries that should be bundled with the plugin
+
+include(../CMakeLists.txt)
+
+include(CMakePrintHelpers)
+cmake_print_variables(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${PLUGIN_NAME}
+                      CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+
 set(dart_wormhole_william_bundled_libraries
-    ""
+    "" ${WORMHOLE_WILLIAM_LIB}
     PARENT_SCOPE)

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,26 +1,32 @@
 cmake_minimum_required(VERSION 3.10)
 set(PROJECT_NAME "dart_wormhole_william")
-project(${PROJECT_NAME} LANGUAGES CXX)
+project(${PROJECT_NAME} LANGUAGES CXX C)
 
-# This value is used when generating builds using this plugin, so it must
-# not be changed
+# This value is used when generating builds using this plugin, so it must not be
+# changed
 set(PLUGIN_NAME "dart_wormhole_william_plugin")
 
+execute_process(
+  COMMAND go tool cgo c/client.c.go
+  COMMAND_ERROR_IS_FATAL LAST
+  WORKING_DIRECTORY
+    ${CMAKE_SOURCE_DIR}/../dart_wormhole_william/wormhole-william)
+
+set(WORMHOLE_C_WRAPPER_BASE
+    "${CMAKE_SOURCE_DIR}/../dart_wormhole_william/wormhole-william/_obj")
+file(GLOB_RECURSE WORMHOLE_C_WRAPPER_SRC ${WORMHOLE_C_WRAPPER_BASE}/*.c
+     ${WORMHOLE_C_WRAPPER_BASE}/*.h)
 add_library(${PLUGIN_NAME} SHARED
-  "dart_wormhole_william_plugin.cc"
-)
-#target_link_libraries(${PLUGIN_NAME} ${CMAKE_SOURCE_DIR}/../wormhole-william/wormhole.a)
-apply_standard_settings(${PLUGIN_NAME})
-set_target_properties(${PLUGIN_NAME} PROPERTIES
-  CXX_VISIBILITY_PRESET hidden)
+            "dart_wormhole_william_plugin.cc;${WORMHOLE_C_WRAPPER_SRC}")
+
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
-target_include_directories(${PLUGIN_NAME} INTERFACE
-  "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_include_directories(
+  ${PLUGIN_NAME}
+  INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include;${WORMHOLE_C_WRAPPER_BASE}")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(dart_wormhole_william_bundled_libraries
-  ""
-  PARENT_SCOPE
-)
+    ""
+    PARENT_SCOPE)


### PR DESCRIPTION
This change provides a base CMake file for building the cgo dependency used by flutter for use in other builds(Windows, Linux, Android, iOS, OSX) and integrates it to Linux and Android builds. Further integration/testing work is needed for the other platforms.

- [x] Add automation to generate the c files with cgo either as part of the cmake file or otherwise