### PR TITLE
Fix macOS library loading issue

### DIFF
--- a/lib/client/native_client.dart
+++ b/lib/client/native_client.dart
@@ -140,7 +140,8 @@ class Config {
 }
 
 class NativeClient {
-  //late final DynamicLibrary _wormholeWilliamLib;
+  // ignore: unused_field
+  late final DynamicLibrary _wormholeWilliamLib;
   late final DynamicLibrary _asyncCallbackLib;
 
   late final Config config;
@@ -150,6 +151,8 @@ class NativeClient {
     if (Platform.isIOS) {
       _asyncCallbackLib = DynamicLibrary.executable();
     } else {
+      // Necessary to load library for macOS to work
+      _wormholeWilliamLib = DynamicLibrary.open(libName("wormhole_william"));
       _asyncCallbackLib = DynamicLibrary.open(libName("bindings"));
     }
 

--- a/macos/dart_wormhole_william.podspec
+++ b/macos/dart_wormhole_william.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.version          = '0.0.1'
   s.summary          = 'A new flutter plugin project.'
   s.prepare_command = <<-CMD
-        mkdir build
+        mkdir -p build
 			  cd build
 			  cmake --trace ../
 			  make


### PR DESCRIPTION
Testing version 1.0.3, macOS was not loading necessary libraries:
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: Invalid argument(s): Failed to load dynamic library 'libbindings.dylib': dlopen(libbindings.dylib, 0x0001): Library not loaded: libwormhole_william.dylib
  Referenced from: <566CA65D-B04F-3FE5-8E72-8C57A09AB7BA> /Applications/Destiny.app/Contents/Frameworks/libbindings.dylib
```

Rollback one change, which impacted loading. Strangely, issue only actual for macOS and not affected by Linux, Windows.

